### PR TITLE
Remove global state

### DIFF
--- a/checkswipe.css
+++ b/checkswipe.css
@@ -10,6 +10,12 @@
   transition: transform var(--checkswipe-duration) var(--checkswipe-easing) var(--checkswipe-delay);
 }
 
-[data-checkswipe=enlarged] input[type=checkbox] {
+[data-checkswipe=checked] input[type=checkbox],
+[data-checkswipe=unchecked] input[type=checkbox] {
   transform: scale(var(--checkswipe-scale));
 }
+
+/* todo:
+    how well supported is `:is()`?
+    ah, no IE9 support :(
+*/

--- a/checkswipe.js
+++ b/checkswipe.js
@@ -1,19 +1,27 @@
-let checkswipeCurrentFieldset = undefined
-let checkswipeGlobalCheckboxState = undefined
-
 function checkswipeAttachSingle(checkbox, parent) {
     checkbox.addEventListener('mousedown', () => {
-        const newState = !checkbox.checked
-        checkswipeGlobalCheckboxState = newState
-        checkbox.checked = newState
-        checkswipeCurrentFieldset = parent
-        parent.dataset.checkswipe = 'enlarged'
+        const state = !checkbox.checked
+        checkbox.checked = state
+        parent.dataset.checkswipe = state ? 'checked' : 'unchecked'
         checkbox.dispatchEvent(new Event('change'))
+
+        const temporaryMouseUpHandler = () => {
+            parent.dataset.checkswipe = ''
+            document.removeEventListener('mouseup', temporaryMouseUpHandler)
+        }
+
+        document.addEventListener('mouseup', temporaryMouseUpHandler)
     })
 
     checkbox.addEventListener('mousemove', () => {
-        if (checkswipeCurrentFieldset === parent && checkswipeGlobalCheckboxState !== undefined && checkswipeGlobalCheckboxState !== checkbox.checked) {
-            checkbox.checked = checkswipeGlobalCheckboxState
+        let state = parent.dataset.checkswipe
+        if (state !== 'checked' && state !== 'unchecked') {
+            return
+        }
+
+        const checked = state === 'checked'
+        if (checked !== checkbox.checked) {
+            checkbox.checked = checked
             checkbox.dispatchEvent(new Event('change'))
         }
     })
@@ -37,16 +45,6 @@ function checkswipeAttachGroup(group) {
         checkswipeAttachSingle(checkbox, group)
     }
 }
-
-document.addEventListener('mouseup', () => {
-    if (!checkswipeCurrentFieldset) {
-        return
-    }
-
-    checkswipeCurrentFieldset.dataset.checkswipe = ''
-    checkswipeGlobalCheckboxState = undefined
-    checkswipeCurrentFieldset = undefined
-})
 
 // attach listeners on load
 const groups = document.querySelectorAll('[data-checkswipe]')

--- a/checkswipe.js
+++ b/checkswipe.js
@@ -2,13 +2,6 @@ let checkswipeCurrentFieldset = undefined
 let checkswipeGlobalCheckboxState = undefined
 
 function checkswipeAttachSingle(checkbox, parent) {
-    checkbox.addEventListener('click', (event) => {
-        // prevent default when clicking directly on the checkbox (not when clicking on labels)
-        if (event instanceof MouseEvent && event.detail > 0) {
-            event.preventDefault()
-        }
-    })
-
     checkbox.addEventListener('mousedown', () => {
         const newState = !checkbox.checked
         checkswipeGlobalCheckboxState = newState
@@ -22,6 +15,13 @@ function checkswipeAttachSingle(checkbox, parent) {
         if (checkswipeCurrentFieldset === parent && checkswipeGlobalCheckboxState !== undefined && checkswipeGlobalCheckboxState !== checkbox.checked) {
             checkbox.checked = checkswipeGlobalCheckboxState
             checkbox.dispatchEvent(new Event('change'))
+        }
+    })
+
+    checkbox.addEventListener('click', (event) => {
+        // prevent default when clicking directly on the checkbox (not when clicking on labels)
+        if (event instanceof MouseEvent && event.detail > 0) {
+            event.preventDefault()
         }
     })
 }


### PR DESCRIPTION
Keep track of state entirely by group's attribute `data-checkswipe`, which now is either `checked` or `unchecked`.

CSS rules are updated to match this. To support IE9, the `:is()` selector is not used :(