### PR TITLE
Require manually call function for attaching to all groups in document

### DIFF
--- a/checkswipe.js
+++ b/checkswipe.js
@@ -46,8 +46,9 @@ function checkswipeAttachGroup(group) {
     }
 }
 
-// attach listeners on load
-const groups = document.querySelectorAll('[data-checkswipe]')
-for (const group of Array.from(groups)) {
-    checkswipeAttachGroup(group)
+function checkswipe() {
+    const groups = document.querySelectorAll('[data-checkswipe]')
+    for (const group of Array.from(groups)) {
+        checkswipeAttachGroup(group)
+    }
 }

--- a/website/index.html
+++ b/website/index.html
@@ -15,7 +15,7 @@
     <link rel=stylesheet href=the.style.css>
 
     <!-- only things related to checkswipe -->
-    <script defer src=checkswipe.js></script>
+    <script defer src=checkswipe.js onload=checkswipe()></script>
     <link rel=stylesheet href=checkswipe.css>
 </head>
 
@@ -50,7 +50,7 @@
     </form>
 
     <h2>Get it</h2>
-    <pre><code>&lt;<span class=kw>script</span> <span class=attr>src</span>=<span class=v>/js/<a href=https://github.com/vladdeSV/checkswipe/releases/latest>checkswipe.js</a></span> <span class=attr>defer</span>&gt;&lt;/<span class=kw>script</span>&gt;<br>&lt;<span class=kw>link</span> <span class=attr>href</span>=<span class=v>/css/<a href=https://github.com/vladdeSV/checkswipe/releases/latest>checkswipe.css</a></span> <span class=attr>rel</span>=<span class=v>stylesheet</span>&gt; <span class=comment>&lt;!-- optional --&gt;</span></code></pre>
+    <pre><code>&lt;<span class=kw>script</span> <span class=attr>src</span>=<span class=v>/js/<a href=https://github.com/vladdeSV/checkswipe/releases/latest>checkswipe.js</a></span> <span class=attr>defer</span> <span class=attr>onload</span>=<span class=fn>checkswipe</span>()&gt;&lt;/<span class=kw>script</span>&gt;<br>&lt;<span class=kw>link</span> <span class=attr>href</span>=<span class=v>/css/<a href=https://github.com/vladdeSV/checkswipe/releases/latest>checkswipe.css</a></span> <span class=attr>rel</span>=<span class=v>stylesheet</span>&gt; <span class=comment>&lt;!-- optional --&gt;</span></code></pre>
     <pre><code>&lt;<span class=kw>fieldset</span> <mark><span class=attr>data-checkswipe</span></mark>&gt;<br>  &lt;<span class=kw>input</span> <span class=attr>type</span>=<span class=v>checkbox</span>&gt;<br>  &lt;<span class=kw>input</span> <span class=attr>type</span>=<span class=v>checkbox</span>&gt;<br>&lt;/<span class=kw>fieldset</span>&gt;</code></pre>
 
     <p>To enable Checkswipe.js on page load, add the attribute <code><span class=attr>data-checkswipe</span></code> to any element – preferably <code>&lt;<span class=kw>fieldset</span>&gt;</code>.</p>


### PR DESCRIPTION
BREAKING CHANGE: No longer automatically attach to all listeners, and instead requires user to manually call a function `checkswipe()` to attach to all groups.

Suggested use case:
```html
<script src=/js/checkswipe.js defer onload=checkswipe()></script>
```