### PR TITLE
Unified function name

### DIFF
--- a/checkswipe.js
+++ b/checkswipe.js
@@ -1,54 +1,66 @@
-function checkswipeAttachSingle(checkbox, parent) {
-    checkbox.addEventListener('mousedown', () => {
-        const state = !checkbox.checked
-        checkbox.checked = state
-        parent.dataset.checkswipe = state ? 'checked' : 'unchecked'
-        checkbox.dispatchEvent(new Event('change'))
-
-        const temporaryMouseUpHandler = () => {
-            parent.dataset.checkswipe = ''
-            document.removeEventListener('mouseup', temporaryMouseUpHandler)
-        }
-
-        document.addEventListener('mouseup', temporaryMouseUpHandler)
-    })
-
-    checkbox.addEventListener('mousemove', () => {
-        let state = parent.dataset.checkswipe
-        if (state !== 'checked' && state !== 'unchecked') {
-            return
-        }
-
-        const checked = state === 'checked'
-        if (checked !== checkbox.checked) {
-            checkbox.checked = checked
+/**
+ * @param {HTMLElement} [parent]
+ * @param {HTMLInputElement} [checkbox]
+ */
+function checkswipe(parent, checkbox) {
+    /**
+     * @param {HTMLInputElement} checkbox
+     * @param {HTMLElement} parent
+     */
+    function attachSingle(checkbox, parent) {
+        checkbox.addEventListener('mousedown', () => {
+            const state = !checkbox.checked
+            checkbox.checked = state
+            parent.dataset.checkswipe = state ? 'checked' : 'unchecked'
             checkbox.dispatchEvent(new Event('change'))
-        }
-    })
 
-    checkbox.addEventListener('click', (event) => {
-        // prevent default when clicking directly on the checkbox (not when clicking on labels)
-        if (event instanceof MouseEvent && event.detail > 0) {
-            event.preventDefault()
-        }
-    })
-}
+            const temporaryMouseUpHandler = () => {
+                parent.dataset.checkswipe = ''
+                document.removeEventListener('mouseup', temporaryMouseUpHandler)
+            }
 
-function checkswipeAttachGroup(group) {
-    const checkboxes = group.querySelectorAll('input[type=checkbox]')
+            document.addEventListener('mouseup', temporaryMouseUpHandler)
+        })
 
-    if (!group.dataset.checkswipe) {
-        group.dataset.checkswipe = ''
+        checkbox.addEventListener('mousemove', () => {
+            let state = parent.dataset.checkswipe
+            if (state !== 'checked' && state !== 'unchecked') {
+                return
+            }
+
+            const checked = state === 'checked'
+            if (checked !== checkbox.checked) {
+                checkbox.checked = checked
+                checkbox.dispatchEvent(new Event('change'))
+            }
+        })
+
+        checkbox.addEventListener('click', (event) => {
+            if (event instanceof MouseEvent && event.detail > 0) {
+                event.preventDefault()
+            }
+        })
     }
 
-    for (const checkbox of Array.from(checkboxes)) {
-        checkswipeAttachSingle(checkbox, group)
+    /**
+     * @param {HTMLElement} group
+     */
+    function attachGroup(group) {
+        const checkboxes = group.querySelectorAll('input[type=checkbox]')
+        if (!group.dataset.checkswipe) {
+            group.dataset.checkswipe = ''
+        }
+        checkboxes.forEach(checkbox => attachSingle(checkbox, group))
     }
-}
 
-function checkswipe() {
-    const groups = document.querySelectorAll('[data-checkswipe]')
-    for (const group of Array.from(groups)) {
-        checkswipeAttachGroup(group)
+    if (!parent && !checkbox) {
+        const groups = document.querySelectorAll('[data-checkswipe]')
+        groups.forEach(group => attachGroup(group))
+    } else if (parent && !checkbox) {
+        attachGroup(parent)
+    } else if (parent && checkbox) {
+        attachSingle(checkbox, parent)
+    } else {
+        throw new Error('checkswipe: `parent` cannot be missing if `checkbox` is provided')
     }
 }

--- a/website/index.html
+++ b/website/index.html
@@ -78,7 +78,7 @@
                     </fieldset>
                     <p><span data-timer data-best-display=–>–</span></p>
                     <div class=reset>
-                        <button type=reset>reset</button>
+                        <button type=reset>reset timer</button>
                     </div>
                 </form>
             </div>
@@ -95,7 +95,7 @@
                     </fieldset>
                     <p><span data-timer data-best-display=–>–</span></p>
                     <div class=reset>
-                        <button type=reset>reset</button>
+                        <button type=reset>reset timer</button>
                     </div>
                 </form>
             </div>
@@ -157,7 +157,7 @@
             timerDisplay.dataset.bestDisplay = '–';
             timerDisplay.textContent = '–';
 
-            resetContainer.innerHTML = '<button type=reset>reset</button>'
+            resetContainer.innerHTML = '<button type=reset>reset timer</button>'
             const reset = resetContainer.querySelector('button[type=reset]')
             reset.addEventListener('click', () => {
                 clearInterval(intervals[form.dataset.checkswipe !== undefined ? 0 : 1]);

--- a/website/index.html
+++ b/website/index.html
@@ -117,7 +117,7 @@
 
     <h2>Advanced</h2>
     <p>Checkswipe can be manually applied to any element, or specific checkboxes:</p>
-    <pre><code><span class=fn>checkswipeAttachGroup</span>(group) <span class=comment>// eg. checkswipeAttachGroup(myCheckboxDiv)</span><br><span class=fn>checkswipeAttachSingle</span>(checkbox, parentGroup) <span class=comment>// eg. checkswipeAttach(checkbox, myCheckboxDiv)</span></code></pre>
+    <pre><code><span class=fn>checkswipe</span>() <span class=comment>// all <span class=attr>[data-checkswipe]</span> on page</span><br><span class=fn>checkswipe</span>(group) <span class=comment>// eg. checkswipe(myDiv)</span><br><span class=fn>checkswipe</span>(group, checkbox) <span class=comment>// eg. checkswipe(myDiv, checkbox)</span></code></pre>
 </main>
 
 <script>
@@ -199,7 +199,7 @@
             }
 
             if (fieldset.hasAttribute('data-checkswipe')) {
-                checkswipeAttachGroup(fieldset)
+                checkswipe(fieldset)
             }
         })
     }

--- a/website/index.html
+++ b/website/index.html
@@ -112,7 +112,7 @@
     <h2>How it works</h2>
     <p>Looks for every <code>&lt;<span class=kw><i>element</i></span>&gt;</code> with the attribute <code><span class=attr>data-checkswipe</span></code>, and attaches a listener to each checkbox inside. Each <code>&lt;<span class=kw><i>element</i></span>&gt;</code> is independent, and only checkboxes within them can be swiped.</p>
     <p>Intentionally only activates when pressing and dragging over checkboxes – does not affect labels and their text.</p>
-    <p>Checkboxes growing larger is pure and simple <abbr title='cascading style sheets'>CSS</abbr>, and is not required.</p>
+    <p>Checkboxes growing larger is pure and simple <abbr title='cascading style sheets'>CSS</abbr>, and is not required – but recommended.</p>
     <p>Caveat: Each <code>&lt;<span class=kw>input</span> <span class=attr>type</span>=<span class=v>checkbox</span>&gt;</code> gets event listeners – adding or replacing the elements requires to re-run code.</p>
 
     <h2>Advanced</h2>

--- a/website/the.style.css
+++ b/website/the.style.css
@@ -39,6 +39,10 @@ header .slogan {
   width: 200px;
 }
 
+.game button[type=reset] {
+  padding-block: 0.4em;
+}
+
 [data-timer] {
   font-family: monospace;
 }


### PR DESCRIPTION
Instead of providing separate functions for each alternative, they are now combined into a single function name:
- `checkswipeAttachGroup(group)` -> `checkswipe(group)`
- `checkswipeAttachSingle(checkbox, group)` -> `checkswipe(group, checkbox)`