### PR TITLE
feat: specify checkboxes to be swipeable

### DIFF
--- a/checkswipe.css
+++ b/checkswipe.css
@@ -6,10 +6,12 @@
   --checkswipe-easing: cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
 
-[data-checkswipe] input[type=checkbox] {
+[data-checkswipe]:not([data-checkswipe-specify]) input[type=checkbox],
+[data-checkswipe][data-checkswipe-specify] input[type=checkbox][data-checkswipe-use] {
   transition: transform var(--checkswipe-duration) var(--checkswipe-easing) var(--checkswipe-delay);
 }
 
-[data-checkswipe]:not([data-checkswipe='']) input[type=checkbox] {
+[data-checkswipe]:not([data-checkswipe='']):not([data-checkswipe-specify]) input[type=checkbox],
+[data-checkswipe][data-checkswipe-specify]:not([data-checkswipe='']) input[type=checkbox][data-checkswipe-use]{
   transform: scale(var(--checkswipe-scale));
 }

--- a/checkswipe.js
+++ b/checkswipe.js
@@ -22,7 +22,7 @@ function checkswipe(parent, checkbox) {
         }
 
         if (parent.dataset.checkswipeSpecify === undefined && checkbox.dataset.checkswipeUse !== undefined) {
-            throw new Error('checkswipe: `checkbox` is specified to be used (with `data-checkswipe-use`), but `parent` does not have `data-checkswipe-specify` attribute. this is not allowed as it causes inconsistencies – please do not manually checkswipe-ify single checkboxes without proper attributes on the parent.')
+            throw new Error('checkswipe: `checkbox` is set to be specifically used (with `data-checkswipe-use`), but `parent` does not have `data-checkswipe-specify` attribute. this is not allowed as it causes inconsistencies – please do not manually checkswipe-ify single checkboxes without proper attributes on the parent.')
         }
 
         checkbox.addEventListener('mousedown', () => {

--- a/checkswipe.js
+++ b/checkswipe.js
@@ -63,11 +63,6 @@ function checkswipe(parent, checkbox) {
      * @param {HTMLElement} group
      */
     function attachGroup(group) {
-        const hasSpecificCheckbox = group.querySelector('[data-checkswipe-use]') !== null
-        if (hasSpecificCheckbox && group.dataset.checkswipeSpecify === undefined) {
-            group.dataset.checkswipeSpecify = ''
-        }
-
         const checkboxes = group.querySelectorAll('input[type=checkbox]')
         checkboxes.forEach(checkbox => attachSingle(checkbox, group) && console.log('----'))
     }

--- a/checkswipe.js
+++ b/checkswipe.js
@@ -21,6 +21,10 @@ function checkswipe(parent, checkbox) {
             return
         }
 
+        if (parent.dataset.checkswipeSpecify === undefined && checkbox.dataset.checkswipeUse !== undefined) {
+            throw new Error('checkswipe: `checkbox` is specified to be used (with `data-checkswipe-use`), but `parent` does not have `data-checkswipe-specify` attribute. this is not allowed as it causes inconsistencies – please do not manually checkswipe-ify single checkboxes without proper attributes on the parent.')
+        }
+
         checkbox.addEventListener('mousedown', () => {
             const state = !checkbox.checked
             checkbox.checked = state

--- a/checkswipe.js
+++ b/checkswipe.js
@@ -59,6 +59,11 @@ function checkswipe(parent, checkbox) {
      * @param {HTMLElement} group
      */
     function attachGroup(group) {
+        const hasSpecificCheckbox = group.querySelector('[data-checkswipe-use]') !== null
+        if (hasSpecificCheckbox && group.dataset.checkswipeSpecify === undefined) {
+            group.dataset.checkswipeSpecify = ''
+        }
+
         const checkboxes = group.querySelectorAll('input[type=checkbox]')
         checkboxes.forEach(checkbox => attachSingle(checkbox, group) && console.log('----'))
     }

--- a/checkswipe.js
+++ b/checkswipe.js
@@ -17,6 +17,10 @@ function checkswipe(parent, checkbox) {
             parent.dataset.checkswipe = ''
         }
 
+        if (parent.dataset.checkswipeSpecify !== undefined && checkbox.dataset.checkswipeUse === undefined) {
+            return
+        }
+
         checkbox.addEventListener('mousedown', () => {
             const state = !checkbox.checked
             checkbox.checked = state
@@ -56,7 +60,7 @@ function checkswipe(parent, checkbox) {
      */
     function attachGroup(group) {
         const checkboxes = group.querySelectorAll('input[type=checkbox]')
-        checkboxes.forEach(checkbox => attachSingle(checkbox, group))
+        checkboxes.forEach(checkbox => attachSingle(checkbox, group) && console.log('----'))
     }
 
     if (!parent && !checkbox) {

--- a/website/index.html
+++ b/website/index.html
@@ -165,6 +165,39 @@
         <label><input type=checkbox> Option 3</label>
       </fieldset>
     </div>
+
+    <h3>Only target specific checkboxes</h3>
+    <p>Checkswipe can be applied to specific checkboxes, and not the entire group.</p>
+    <table data-checkswipe data-checkswipe-specify>
+      <thead>
+        <tr>
+          <th>Swipeable</th>
+          <th>Text</th>
+          <th>Optional 1</th>
+          <th>Optional 2</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><input type=checkbox data-checkswipe-use></td>
+          <td>Foofoo</td>
+          <td><input type=checkbox></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td><input type=checkbox data-checkswipe-use></td>
+          <td>Barbar</td>
+          <td><input type=checkbox></td>
+          <td><input type=checkbox></td>
+        </tr>
+        <tr>
+          <td><input type=checkbox data-checkswipe-use></td>
+          <td>Bazbaz</td>
+          <td></td>
+          <td><input type=checkbox></td
+        </tr>
+      </tbody>
+    </table>
 </main>
 </body>
 

--- a/website/index.html
+++ b/website/index.html
@@ -167,14 +167,28 @@
     </div>
 
     <h3>Only target specific checkboxes</h3>
-    <p>Checkswipe can be applied to specific checkboxes, and not the entire group.</p>
-    <table data-checkswipe data-checkswipe-specify>
+    <p>Include the attribute <code><span class=attr>data-checkswipe-use</span></code> on the checkboxes you want to be swipeable, and the other checkboxes will remain untouched.</p>
+
+    <fieldset data-checkswipe>
+      <legend>Semi-swipeable checkboxes</legend>
+      <label><input type=checkbox data-checkswipe-use> Option 1</label>
+      <label><input type=checkbox data-checkswipe-use> Option 2</label>
+      <label><input type=checkbox> Option 3 (non-swipeable)</label>
+      <label><input type=checkbox data-checkswipe-use> Option 4</label>
+      <label><input type=checkbox data-checkswipe-use> Option 5</label>
+    </fieldset>
+
+    <h4>Tables</h4>
+    <p>Tables are a bit cumbersome since they do not follow a conventional structure, but it's possible to only make checkboxes in certain columns swipeable.</p>
+    <p>If you want to group different columns of checkboxes together, you unfortunately are out of luck.</p>
+
+    <table data-checkswipe>
       <thead>
         <tr>
           <th>Swipeable</th>
           <th>Text</th>
-          <th>Optional 1</th>
-          <th>Optional 2</th>
+          <th>Non-swipe 1</th>
+          <th>Non-swipe 2</th>
         </tr>
       </thead>
       <tbody>

--- a/website/index.html
+++ b/website/index.html
@@ -167,9 +167,9 @@
     </div>
 
     <h3>Only target specific checkboxes</h3>
-    <p>Include the attribute <code><span class=attr>data-checkswipe-use</span></code> on the checkboxes you want to be swipeable, and the other checkboxes will remain untouched.</p>
+    <p>Include the attribute <code><span class=attr>data-checkswipe-specify</span></code> on the group, and add the attribute <code><span class=attr>data-checkswipe-use</span></code> on the checkboxes you want to be swipeable, and the other checkboxes will remain untouched.</p>
 
-    <fieldset data-checkswipe>
+    <fieldset data-checkswipe data-checkswipe-specify>
       <legend>Semi-swipeable checkboxes</legend>
       <label><input type=checkbox data-checkswipe-use> Option 1</label>
       <label><input type=checkbox data-checkswipe-use> Option 2</label>
@@ -179,10 +179,10 @@
     </fieldset>
 
     <h4>Tables</h4>
-    <p>Tables are a bit cumbersome since they do not follow a conventional structure, but it's possible to only make checkboxes in certain columns swipeable.</p>
+    <p>Tables are a bit cumbersome since they do not follow a conventional "grouped" structure, but it's possible to only make checkboxes in certain columns swipeable.</p>
     <p>If you want to group different columns of checkboxes together, you unfortunately are out of luck.</p>
 
-    <table data-checkswipe>
+    <table data-checkswipe data-checkswipe-specify>
       <thead>
         <tr>
           <th>Swipeable</th>

--- a/website/index.html
+++ b/website/index.html
@@ -34,7 +34,7 @@
         </svg>
     </aside>
     <hgroup>
-        <h1>Checkswipe.js <code class=version>v2.0</code></h1>
+        <h1>Checkswipe.js <code class=version>v2.1</code></h1>
         <p><i>"Click-and-drag" over HTML checkboxes</i></p>
     </hgroup>
 </header>


### PR DESCRIPTION
Allow tagging groups with `data-checkswipe-specify`, where only inputs with the attribute `data-checkswipe-use` will be swipeable.